### PR TITLE
Download NVDA portable ZIP from external repo

### DIFF
--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -64,7 +64,9 @@ jobs:
   nvda-test:
     runs-on: windows-2022
     steps:
-
+      - name: setup masks
+        shell: powershell
+        run: echo "::add-mask::$env:ARIA_AT_CALLBACK_HEADER"
       - name: Log job state QUEUED
         shell: powershell
         if: inputs.status_url

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -64,9 +64,7 @@ jobs:
   nvda-test:
     runs-on: windows-2022
     steps:
-      - name: setup masks
-        shell: powershell
-        run: echo "::add-mask::$env:ARIA_AT_CALLBACK_HEADER"
+
       - name: Log job state QUEUED
         shell: powershell
         if: inputs.status_url
@@ -98,6 +96,17 @@ jobs:
           repository: "w3c/aria-at-automation-harness"
           ref: "main"
           path: "aria-at-automation-harness"
+
+      - name: Download nvda-portable zip
+        uses: robinraju/release-downloader@v1.9
+        id: nvda-portable-download
+        with:
+          repository: "bocoup/aria-at-automation-nvda-builds"
+          latest: true
+          tarBall: false
+          zipBall: false
+          out-file-path: "nvda-portable"
+          extract: false
 
       - name: Use Node.js 16.x
         uses: actions/setup-node@v3
@@ -169,6 +178,8 @@ jobs:
       - name: Run harness
         shell: powershell
         continue-on-error: true
+        env:
+          NVDA_PORTABLE_ZIP: ${{ fromJson(steps.nvda-portable-download.outputs.downloaded_files)[0] }}
         run: |
           & .\run-tester.ps1
 

--- a/run-tester.ps1
+++ b/run-tester.ps1
@@ -1,18 +1,18 @@
 
-[string]$nvdaVersion = "2023.3"
+[string]$nvdaVersion = [System.IO.Path]::GetFileNameWithoutExtension($env:NVDA_PORTABLE_ZIP)
 $loglocation = $pwd
 
 Write-Output "Log folder $loglocation"
-
-Expand-Archive -Path $loglocation\nvda-portable\$nvdaVersion.zip -DestinationPath nvda-portable\
 
 $nvdaParams = ""
 if ($env:RUNNER_DEBUG)
 {
   $nvdaParams = "--debug-logging"
 }
-Write-Output "Starting NVDA"
-& "nvda-portable\$nvdaVersion\NVDA.exe" $nvdaParams
+[string]$nvdaFolder = [System.IO.Path]::GetDirectoryName($env:NVDA_PORTABLE_ZIP)
+Expand-Archive -Path "$env:NVDA_PORTABLE_ZIP" -DestinationPath "$nvdaFolder"
+Write-Output "Starting NVDA $nvdaVersion - $nvdaFolder\$nvdaVersion\nvda.exe"
+& "$nvdaFolder\$nvdaVersion\nvda.exe" $nvdaParams
 
 # Retries to connect to an http url, allowing for any valid "response" (4xx,5xx,etc also valid)
 function Wait-For-HTTP-Response {


### PR DESCRIPTION
Fixes #6

Downloads the latest release zip from [bocoup/aria-at-automation-nvda-builds](https://github.com/bocoup/aria-at-automation-nvda-builds) releases.