### PR TITLE
Restore support for legacy workflow

### DIFF
--- a/.github/workflows/nvda-chrome.yml
+++ b/.github/workflows/nvda-chrome.yml
@@ -161,6 +161,8 @@ jobs:
       - name: Run harness
         shell: powershell
         continue-on-error: true
+        env:
+          NVDA_PORTABLE_ZIP: nvda-portable/2023.3.zip
         run: |
           & .\run-tester.ps1
 


### PR DESCRIPTION
In implementing a new GitHub workflow for use in ARIA-AT App ("nvda-test.yml"), a recent commit [1] unintentionally regressed support for the existing GitHub Workflow ("nvda-chrome.yml").

Ensure that the "nvda-chrome.yml" workflow continues to operate as originally intended in order to facilitate an asynchronous transition to the new workflow.

[1] 715a21f0ad25c29518af9de1e7495b5bb2bf5875

---

@gnarf I was tempted to revert 715a21f0ad25c29518af9de1e7495b5bb2bf5875 in order to submit this as a new version of that patch which introduced the new feature atomically and completely. The reversion didn't apply cleanly, though, and resolving the conflicts seemed more complicated (not to mention risky) than warranted.