### PR TITLE
Add timeout to harness run

### DIFF
--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -176,6 +176,7 @@ jobs:
 
       - name: Run harness
         shell: powershell
+        timeout-minutes: 30
         env:
           NVDA_PORTABLE_ZIP: ${{ fromJson(steps.nvda-portable-download.outputs.downloaded_files)[0] }}
         run: |


### PR DESCRIPTION
I discovered an error that rarely happens on the [at-driver for NVDA](https://github.com/Prime-Access-Consulting/nvda-at-automation/issues/50) that causes the harness to hang indefinitely.  Adding a timeout to this step should hopefully stop us from spinning a GH Actions runner forever if this error happens again.