### PR TITLE
Support runs with specific AtVersions

### DIFF
--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -121,11 +121,11 @@ jobs:
               exit 1
           }
 
-          # Check for the asset with the expected name pattern
-          $asset = $release.assets | Where-Object { $_.name -like "nvda-portable*.zip" } | Select-Object -First 1
+          # Check for the zip asset
+          $asset = $release.assets | Where-Object { $_.name -like "*.zip" } | Select-Object -First 1
 
           if ($null -eq $asset) {
-              Write-Error "NVDA portable zip not found in release $($release.tag_name). Available assets are: $($release.assets.name -join ', ')"
+              Write-Error "Zip file not found in release $($release.tag_name). Available assets are: $($release.assets.name -join ', ')"
               exit 1
           }
 
@@ -133,9 +133,6 @@ jobs:
           Invoke-WebRequest -Uri $asset.browser_download_url -OutFile "nvda-portable\$($asset.name)"
           echo "nvda_zip=$($asset.name)" >> $env:GITHUB_OUTPUT
           echo "nvda_version=$($release.tag_name)" >> $env:GITHUB_OUTPUT
-
-      - name: Log NVDA version
-        run: echo "Using NVDA version ${{ steps.nvda-download.outputs.nvda_version }}"
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -102,44 +102,17 @@ jobs:
           ref: "main"
           path: "aria-at-automation-harness"
 
-      - name: Check NVDA version and download
-        id: nvda-download
-        shell: powershell
-        run: |
-          $version = "${{ env.NVDA_VERSION }}"
-          $repo = "bocoup/aria-at-automation-nvda-builds"
-          $apiUrl = "https://api.github.com/repos/$repo/releases"
-
-          # Fetch all releases and store them
-          $releases = Invoke-RestMethod -Uri $apiUrl
-
-          # Check if the specific version is available
-          $release = $releases | Where-Object { $_.tag_name -eq $version } | Select-Object -First 1
-
-          if ($null -eq $release) {
-              Write-Error "NVDA version $version not found in $repo. Available versions are: $($releases.tag_name -join ', ')"
-              exit 1
-          }
-
-          # Adjust the asset name pattern to match the actual asset names
-          $asset = $release.assets | Where-Object { $_.name -like "*.zip" } | Select-Object -First 1
-
-          if ($null -eq $asset) {
-              Write-Error "Zip file not found in release $($release.tag_name). Available assets are: $($release.assets.name -join ', ')"
-              exit 1
-          }
-
-          # Ensure the directory exists before downloading
-          $downloadPath = "nvda-portable"
-          if (-Not (Test-Path -Path $downloadPath)) {
-              New-Item -ItemType Directory -Path $downloadPath
-          }
-
-          # Proceed with download
-          $filePath = Join-Path -Path $downloadPath -ChildPath $asset.name
-          Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $filePath
-          echo "nvda_zip=$($asset.name)" >> $env:GITHUB_OUTPUT
-          echo "nvda_version=$($release.tag_name)" >> $env:GITHUB_OUTPUT
+      - name: Download nvda-portable zip
+        uses: robinraju/release-downloader@v1.9
+        id: nvda-portable-download
+        with:
+          repository: "bocoup/aria-at-automation-nvda-builds"
+          latest: true
+          tarBall: false
+          zipBall: false
+          tag: ${{ inputs.nvda_version }}
+          out-file-path: "nvda-portable"
+          extract: false
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
@@ -212,7 +185,7 @@ jobs:
         shell: powershell
         timeout-minutes: 30
         env:
-          NVDA_PORTABLE_ZIP: ${{ steps.nvda-download.outputs.nvda_zip }}
+          NVDA_PORTABLE_ZIP: ${{ fromJson(steps.nvda-portable-download.outputs.downloaded_files)[0] }}
         run: |
           & .\run-tester.ps1
 

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -46,6 +46,11 @@ on:
           The browser to use for testing, "chrome" or "firefox", default "chrome"
         required: false
         type: string
+      nvda_version:
+        description: |
+          The specific version of NVDA to use (e.g., '2023.1'). If not provided, the latest version will be used.
+        required: false
+        type: string
 
   # seems if push is enabled, I'm not able to trigger via workflow_dispatch?
   # push:
@@ -59,6 +64,7 @@ env:
   ARIA_AT_STATUS_URL: ${{ inputs.status_url }}
   ARIA_AT_CALLBACK_HEADER: ${{ inputs.callback_header || 'x-header-param:empty' }}
   BROWSER: ${{ inputs.browser || 'chrome' }}
+  NVDA_VERSION: ${{ inputs.nvda_version }}
 
 jobs:
   nvda-test:
@@ -96,16 +102,38 @@ jobs:
           ref: "main"
           path: "aria-at-automation-harness"
 
-      - name: Download nvda-portable zip
-        uses: robinraju/release-downloader@v1.9
-        id: nvda-portable-download
-        with:
-          repository: "bocoup/aria-at-automation-nvda-builds"
-          latest: true
-          tarBall: false
-          zipBall: false
-          out-file-path: "nvda-portable"
-          extract: false
+      - name: Check NVDA version and download
+        id: nvda-download
+        shell: powershell
+        run: |
+          $version = "${{ env.NVDA_VERSION }}"
+          $repo = "bocoup/aria-at-automation-nvda-builds"
+          $apiUrl = "https://api.github.com/repos/$repo/releases"
+
+          if ([string]::IsNullOrEmpty($version)) {
+            $release = Invoke-RestMethod -Uri $apiUrl | Select-Object -First 1
+          } else {
+            $release = Invoke-RestMethod -Uri $apiUrl | Where-Object { $_.tag_name -eq $version } | Select-Object -First 1
+          }
+
+          if ($null -eq $release) {
+            Write-Error "NVDA version $version not found in $repo"
+            exit 1
+          }
+
+          $asset = $release.assets | Where-Object { $_.name -like "nvda-portable*.zip" } | Select-Object -First 1
+
+          if ($null -eq $asset) {
+            Write-Error "NVDA portable zip not found in release $($release.tag_name)"
+            exit 1
+          }
+
+          Invoke-WebRequest -Uri $asset.browser_download_url -OutFile "nvda-portable\$($asset.name)"
+          echo "nvda_zip=$($asset.name)" >> $env:GITHUB_OUTPUT
+          echo "nvda_version=$($release.tag_name)" >> $env:GITHUB_OUTPUT
+
+      - name: Log NVDA version
+        run: echo "Using NVDA version ${{ steps.nvda-download.outputs.nvda_version }}"
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
@@ -178,7 +206,7 @@ jobs:
         shell: powershell
         timeout-minutes: 30
         env:
-          NVDA_PORTABLE_ZIP: ${{ fromJson(steps.nvda-portable-download.outputs.downloaded_files)[0] }}
+          NVDA_PORTABLE_ZIP: ${{ steps.nvda-download.outputs.nvda_zip }}
         run: |
           & .\run-tester.ps1
 

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -121,7 +121,7 @@ jobs:
               exit 1
           }
 
-          # Check for the zip asset
+          # Adjust the asset name pattern to match the actual asset names
           $asset = $release.assets | Where-Object { $_.name -like "*.zip" } | Select-Object -First 1
 
           if ($null -eq $asset) {
@@ -129,8 +129,15 @@ jobs:
               exit 1
           }
 
+          # Ensure the directory exists before downloading
+          $downloadPath = "nvda-portable"
+          if (-Not (Test-Path -Path $downloadPath)) {
+              New-Item -ItemType Directory -Path $downloadPath
+          }
+
           # Proceed with download
-          Invoke-WebRequest -Uri $asset.browser_download_url -OutFile "nvda-portable\$($asset.name)"
+          $filePath = Join-Path -Path $downloadPath -ChildPath $asset.name
+          Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $filePath
           echo "nvda_zip=$($asset.name)" >> $env:GITHUB_OUTPUT
           echo "nvda_version=$($release.tag_name)" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -110,24 +110,26 @@ jobs:
           $repo = "bocoup/aria-at-automation-nvda-builds"
           $apiUrl = "https://api.github.com/repos/$repo/releases"
 
-          if ([string]::IsNullOrEmpty($version)) {
-            $release = Invoke-RestMethod -Uri $apiUrl | Select-Object -First 1
-          } else {
-            $release = Invoke-RestMethod -Uri $apiUrl | Where-Object { $_.tag_name -eq $version } | Select-Object -First 1
-          }
+          # Fetch all releases and store them
+          $releases = Invoke-RestMethod -Uri $apiUrl
+
+          # Check if the specific version is available
+          $release = $releases | Where-Object { $_.tag_name -eq $version } | Select-Object -First 1
 
           if ($null -eq $release) {
-            Write-Error "NVDA version $version not found in $repo"
-            exit 1
+              Write-Error "NVDA version $version not found in $repo. Available versions are: $($releases.tag_name -join ', ')"
+              exit 1
           }
 
+          # Check for the asset with the expected name pattern
           $asset = $release.assets | Where-Object { $_.name -like "nvda-portable*.zip" } | Select-Object -First 1
 
           if ($null -eq $asset) {
-            Write-Error "NVDA portable zip not found in release $($release.tag_name)"
-            exit 1
+              Write-Error "NVDA portable zip not found in release $($release.tag_name). Available assets are: $($release.assets.name -join ', ')"
+              exit 1
           }
 
+          # Proceed with download
           Invoke-WebRequest -Uri $asset.browser_download_url -OutFile "nvda-portable\$($asset.name)"
           echo "nvda_zip=$($asset.name)" >> $env:GITHUB_OUTPUT
           echo "nvda_version=$($release.tag_name)" >> $env:GITHUB_OUTPUT

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -107,7 +107,6 @@ jobs:
         id: nvda-portable-download
         with:
           repository: "bocoup/aria-at-automation-nvda-builds"
-          latest: true
           tarBall: false
           zipBall: false
           tag: ${{ inputs.nvda_version }}

--- a/.github/workflows/voiceover-test.yml
+++ b/.github/workflows/voiceover-test.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Check macOS version
         if: inputs.macos_version != '' && matrix.macos != inputs.macos_version
-        run: exit 0
+        run: exit 1
 
       - name: Log job state QUEUED
         if: inputs.status_url

--- a/.github/workflows/voiceover-test.yml
+++ b/.github/workflows/voiceover-test.yml
@@ -58,14 +58,20 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check macOS version
-        if: inputs.macos_version != '' && matrix.macos != inputs.macos_version
-        run: exit 1
+        id: check_macos
+        run: |
+          if [[ "${{ inputs.macos_version }}" == "" || "${{ matrix.macos }}" == "${{ inputs.macos_version }}" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Log job state QUEUED
-        if: inputs.status_url
+        if: inputs.status_url && steps.check_macos.outputs.should_run == 'true'
         run: ./report-status.sh QUEUED ''
 
       - uses: robinraju/release-downloader@v1.10
+        if: steps.check_macos.outputs.should_run == 'true'
         with:
           repository: "w3c/aria-at-automation-driver"
           tag: "v0.0.1-beta"
@@ -74,53 +80,64 @@ jobs:
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
+        if: steps.check_macos.outputs.should_run == 'true'
         with:
           node-version: 18.x
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
 
       - name: Setup Environment
+        if: steps.check_macos.outputs.should_run == 'true'
         uses: guidepup/setup-action@0.15.3
 
       - name: "automation-driver: npm install"
+        if: steps.check_macos.outputs.should_run == 'true'
         working-directory: aria-at-automation-driver/package
         run: npm install
 
       - name: "automation-driver: install"
+        if: steps.check_macos.outputs.should_run == 'true'
         env:
           DEBUG: "*"
         working-directory: aria-at-automation-driver/package
         run: ./bin/at-driver install --unattended
 
       - name: Wait for server to be ready
+        if: steps.check_macos.outputs.should_run == 'true'
         working-directory: aria-at-automation-driver/package
         run: ../../wait-for-server.sh
 
       - name: Checkout aria-at ref ${{ inputs.aria_at_ref || 'master' }}
+        if: steps.check_macos.outputs.should_run == 'true'
         uses: actions/checkout@v4
         with:
           repository: "w3c/aria-at"
           path: "aria-at"
 
       - name: Checkout aria-at-automation-harness
+        if: steps.check_macos.outputs.should_run == 'true'
         uses: actions/checkout@v4
         with:
           repository: "w3c/aria-at-automation-harness"
           path: "aria-at-automation-harness"
 
       - name: "aria-at: npm install"
+        if: steps.check_macos.outputs.should_run == 'true'
         working-directory: aria-at
         run: npm install
 
       - name: "aria-at: npm run build"
+        if: steps.check_macos.outputs.should_run == 'true'
         working-directory: aria-at
         run: npm run build
 
       - name: "automation-harness: npm install"
+        if: steps.check_macos.outputs.should_run == 'true'
         working-directory: aria-at-automation-harness
         run: npm install
 
       - name: Start VoiceOver
+        if: steps.check_macos.outputs.should_run == 'true'
         run: "/System/Library/CoreServices/VoiceOver.app/Contents/MacOS/VoiceOverStarter"
 
         # This feature must be enabled in order for the harness to inspect the
@@ -130,26 +147,28 @@ jobs:
         # tests must simulate).
         # https://stackoverflow.com/questions/37802673/allow-javascript-from-apple-events-in-safari-through-terminal-mac
       - name: Configure Safari to Allow JavaScript from Apple Events
+        if: steps.check_macos.outputs.should_run == 'true'
         run: defaults write -app Safari AllowJavaScriptFromAppleEvents 1
 
       - name: Log job state RUNNING
-        if: inputs.status_url
+        if: inputs.status_url && steps.check_macos.outputs.should_run == 'true'
         run: './report-status.sh RUNNING "\"work_dir\": \"${ARIA_AT_WORK_DIR}\","'
 
       - name: Run harness
+        if: steps.check_macos.outputs.should_run == 'true'
         run: ./run-tester.sh
 
       - name: Log job state ERROR
-        if: failure() && inputs.status_url
+        if: failure() && inputs.status_url && steps.check_macos.outputs.should_run == 'true'
         run: ./report-status.sh ERROR ''
 
       - name: Log job state COMPLETED
-        if: success() && inputs.status_url
+        if: success() && inputs.status_url && steps.check_macos.outputs.should_run == 'true'
         run: ./report-status.sh COMPLETED ''
 
       - name: upload *.{log,png}
         uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && steps.check_macos.outputs.should_run == 'true'
         with:
           name: logs
           path: |

--- a/.github/workflows/voiceover-test.yml
+++ b/.github/workflows/voiceover-test.yml
@@ -32,6 +32,14 @@ on:
           with status updates.
         required: false
         type: string
+      macos_version:
+        description: "macOS version to run the test on"
+        required: false
+        type: choice
+        options:
+          - "13"
+          - "14"
+        default: "14"
 
 env:
   ARIA_AT_WORK_DIR: ${{ inputs.work_dir || 'tests/alert' }}
@@ -41,11 +49,17 @@ env:
 
 jobs:
   voiceover-test:
-    runs-on: macos-14
+    strategy:
+      matrix:
+        macos: ["13", "14"]
+    runs-on: macos-${{ matrix.macos }}
     steps:
-
       # Checkout all repos first (helps cache purposes)
       - uses: actions/checkout@v4
+
+      - name: Check macOS version
+        if: inputs.macos_version != '' && matrix.macos != inputs.macos_version
+        run: exit 0
 
       - name: Log job state QUEUED
         if: inputs.status_url
@@ -53,8 +67,8 @@ jobs:
 
       - uses: robinraju/release-downloader@v1.10
         with:
-          repository: 'w3c/aria-at-automation-driver'
-          tag: 'v0.0.1-beta'
+          repository: "w3c/aria-at-automation-driver"
+          tag: "v0.0.1-beta"
           extract: true
           out-file-path: aria-at-automation-driver
 
@@ -74,7 +88,7 @@ jobs:
 
       - name: "automation-driver: install"
         env:
-          DEBUG: '*'
+          DEBUG: "*"
         working-directory: aria-at-automation-driver/package
         run: ./bin/at-driver install --unattended
 


### PR DESCRIPTION
## Overview

This PR adds support for specifying the AT version that a runner should use. 

## Notes
- Thanks Corey for the matrix with an early exit suggestion!
- I opted for using conditionals in every action for the early exit so that that part of the matrix shows as completed rather than errored. It is verbose and I am open to alternatives if anyone has a suggestion.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207376193363744