### PR TITLE
Hotfix:  Fallback to latest NVDA

### DIFF
--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -193,8 +193,11 @@ jobs:
         shell: powershell
         timeout-minutes: 30
         env:
-          NVDA_PORTABLE_ZIP: ${{ inputs.nvda_version == '' && steps.nvda-portable-download-latest.outputs.downloaded_files[0] || steps.nvda-portable-download-specific.outputs.downloaded_files[0] }}
+          NVDA_PORTABLE_ZIP: ${{ inputs.nvda_version != '' && steps.nvda-portable-download-specific.outputs.downloaded_files || steps.nvda-portable-download-latest.outputs.downloaded_files }}
         run: |
+          $nvdaZip = $env:NVDA_PORTABLE_ZIP -replace '[\[\]\"]', '' -split ',' | Select-Object -First 1
+          Write-Host "Using NVDA zip: $nvdaZip"
+          $env:NVDA_PORTABLE_ZIP = $nvdaZip
           & .\run-tester.ps1
 
       - name: Log job state ERROR

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -193,7 +193,7 @@ jobs:
         shell: powershell
         timeout-minutes: 30
         env:
-          NVDA_PORTABLE_ZIP: ${{ fromJson(steps.nvda-portable-download.outputs.downloaded_files)[0] }}
+          NVDA_PORTABLE_ZIP: ${{ inputs.nvda_version != '' && steps.nvda-portable-download-specific.outputs.downloaded_files[0] || steps.nvda-portable-download-latest.outputs.downloaded_files[0] }}
         run: |
           & .\run-tester.ps1
 

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -102,16 +102,25 @@ jobs:
           ref: "main"
           path: "aria-at-automation-harness"
 
-      - name: Download nvda-portable zip
+      - name: Download nvda-portable zip (specific version)
+        if: inputs.nvda_version != null
         uses: robinraju/release-downloader@v1.9
-        id: nvda-portable-download
+        id: nvda-portable-download-specific
         with:
           repository: "bocoup/aria-at-automation-nvda-builds"
-          tarBall: false
-          zipBall: false
-          tag: ${{ inputs.nvda_version || 'latest' }}
+          tag: ${{ inputs.nvda_version }}
+          fileName: "*"
           out-file-path: "nvda-portable"
-          extract: false
+
+      - name: Download nvda-portable zip (latest)
+        if: inputs.nvda_version == null
+        uses: robinraju/release-downloader@v1.9
+        id: nvda-portable-download-latest
+        with:
+          repository: "bocoup/aria-at-automation-nvda-builds"
+          latest: true
+          fileName: "*"
+          out-file-path: "nvda-portable"
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -109,7 +109,7 @@ jobs:
           repository: "bocoup/aria-at-automation-nvda-builds"
           tarBall: false
           zipBall: false
-          tag: ${{ inputs.nvda_version }}
+          tag: ${{ inputs.nvda_version || 'latest' }}
           out-file-path: "nvda-portable"
           extract: false
 

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -102,25 +102,17 @@ jobs:
           ref: "main"
           path: "aria-at-automation-harness"
 
-      - name: Download nvda-portable zip (specific version)
-        if: inputs.nvda_version != null
+      - name: Download nvda-portable zip
         uses: robinraju/release-downloader@v1.9
-        id: nvda-portable-download-specific
+        id: nvda-portable-download
         with:
           repository: "bocoup/aria-at-automation-nvda-builds"
+          tarBall: false
+          zipBall: false
           tag: ${{ inputs.nvda_version }}
-          fileName: "*"
+          latest: ${{ inputs.nvda_version == '' }}
           out-file-path: "nvda-portable"
-
-      - name: Download nvda-portable zip (latest)
-        if: inputs.nvda_version == null
-        uses: robinraju/release-downloader@v1.9
-        id: nvda-portable-download-latest
-        with:
-          repository: "bocoup/aria-at-automation-nvda-builds"
-          latest: true
-          fileName: "*"
-          out-file-path: "nvda-portable"
+          extract: false
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
@@ -193,11 +185,8 @@ jobs:
         shell: powershell
         timeout-minutes: 30
         env:
-          NVDA_PORTABLE_ZIP: ${{ inputs.nvda_version != '' && steps.nvda-portable-download-specific.outputs.downloaded_files || steps.nvda-portable-download-latest.outputs.downloaded_files }}
+          NVDA_PORTABLE_ZIP: ${{ fromJson(steps.nvda-portable-download.outputs.downloaded_files)[0] }}
         run: |
-          $nvdaZip = $env:NVDA_PORTABLE_ZIP -replace '[\[\]\"]', '' -split ',' | Select-Object -First 1
-          Write-Host "Using NVDA zip: $nvdaZip"
-          $env:NVDA_PORTABLE_ZIP = $nvdaZip
           & .\run-tester.ps1
 
       - name: Log job state ERROR

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -193,7 +193,7 @@ jobs:
         shell: powershell
         timeout-minutes: 30
         env:
-          NVDA_PORTABLE_ZIP: ${{ inputs.nvda_version != '' && steps.nvda-portable-download-specific.outputs.downloaded_files[0] || steps.nvda-portable-download-latest.outputs.downloaded_files[0] }}
+          NVDA_PORTABLE_ZIP: ${{ inputs.nvda_version == '' && steps.nvda-portable-download-latest.outputs.downloaded_files[0] || steps.nvda-portable-download-specific.outputs.downloaded_files[0] }}
         run: |
           & .\run-tester.ps1
 


### PR DESCRIPTION
This fixes a bug created by merging #21 before [aria-at-app/1144](https://github.com/w3c/aria-at-app/pull/1144) is merged. 

I made the mistake of thinking that the Github action that we are using to fetch releases of NVDA would fall back to the latest release. I also made the mistake of thinking that I had tested this behavior.

This PR adds fallback behavior so that when an `at_version` is not provided to an NVDA workflow, the latest is used.