### PR TITLE
Add a script to cancel all GitHub workflow runs in a repo

### DIFF
--- a/stressor/cancel-all-workflows.mts
+++ b/stressor/cancel-all-workflows.mts
@@ -1,0 +1,40 @@
+import { Octokit } from "@octokit/rest";
+
+const username = "";
+const repoName = "aria-at-gh-actions-helper";
+
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+});
+
+/**
+ * Cancels all incomplete runs of all GitHub Actions workflows in the given repository.
+ * Limited to the last 30 runs by GitHub's API pagination.
+ */
+async function cancelAllWorkflows(owner: string, repo: string) {
+  const workflows = await octokit.actions.listRepoWorkflows({
+    owner,
+    repo,
+  });
+
+  for (const workflow of workflows.data.workflows) {
+    const runs = await octokit.actions.listWorkflowRuns({
+      owner,
+      repo,
+      workflow_id: workflow.id,
+    });
+
+    for (const run of runs.data.workflow_runs) {
+      if (run.status !== "completed") {
+        await octokit.actions.cancelWorkflowRun({
+          owner,
+          repo,
+          run_id: run.id,
+        });
+        console.log(`Cancelled workflow run ${run.id} (${run.status})`);
+      }
+    }
+  }
+}
+
+cancelAllWorkflows(username, repoName);

--- a/stressor/package.json
+++ b/stressor/package.json
@@ -4,7 +4,8 @@
   "description": "Stress test Test Plans via CI workflows",
   "main": "stress-test.mts",
   "scripts": {
-    "stress-test": "node --loader ts-node/esm stress-test.mts"
+    "stress-test": "node --loader ts-node/esm stress-test.mts",
+    "cancel-runs": "node --loader ts-node/esm cancel-all-workflows.mts"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
This is really helpful when you kick off a set of tests and then immediately realize you made a mistake and need to restart the process 😅 