### PR TITLE
Use queue time variables in azure pipeline

### DIFF
--- a/.pipelines/windows-nvda.yml
+++ b/.pipelines/windows-nvda.yml
@@ -92,8 +92,6 @@ steps:
     inputs:
       connection: MyGitHubServiceConnection
       userRepository: bocoup/aria-at-automation-nvda-builds
-      defaultVersionType: specificTag
-      version: $(nvda_version)
       downloadPath: $(helper_dir)/nvda-portable
   - task: DownloadGitHubRelease@0
     condition: ne(variables.nvda_version, 'latest')
@@ -102,6 +100,8 @@ steps:
     inputs:
       connection: MyGitHubServiceConnection
       userRepository: bocoup/aria-at-automation-nvda-builds
+      defaultVersionType: specificTag
+      version: $(nvda_version)
       downloadPath: $(helper_dir)/nvda-portable
   - task: PowerShell@2
     displayName: Setup NVDA_PORTABLE_ZIP

--- a/.pipelines/windows-nvda.yml
+++ b/.pipelines/windows-nvda.yml
@@ -89,15 +89,15 @@ steps:
     displayName: Debug
     inputs:
       targetType: inline
-      ${{ if ne(variables.nvda_version, 'latest') }}:
-        script: Write-Host "Evaluated to true"
+      ${{ if ne(variables.NVDA_VERSION, 'latest') }}:
+        script: Write-Host "Evaluated to true (${env:nvda_version})"
   - task: DownloadGitHubRelease@0
     displayName: Download nvda portable $(nvda_version)
     # https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/download-github-release-v0?view=azure-pipelines
     inputs:
       connection: MyGitHubServiceConnection
       userRepository: bocoup/aria-at-automation-nvda-builds
-      ${{ if ne(variables.nvda_version, 'latest') }}:
+      ${{ if ne(variables.NVDA_VERSION, 'latest') }}:
         defaultVersionType: specificTag
         version: $(nvda_version)
       downloadPath: $(helper_dir)/nvda-portable

--- a/.pipelines/windows-nvda.yml
+++ b/.pipelines/windows-nvda.yml
@@ -91,8 +91,8 @@ steps:
     inputs:
       connection: MyGitHubServiceConnection
       userRepository: bocoup/aria-at-automation-nvda-builds
-      defaultVersionType: $[if(ne(variables['nvda_version'], 'latest'), 'specificTag', 'latestByTag')]
-      version: $[if(ne(variables['nvda_version'], 'latest'), variables['nvda_version'], '')]
+      defaultVersionType: ${{ if(ne(variables['nvda_version'], 'latest'), 'specificTag', 'latestByTag') }}
+      version: ${{ if(ne(variables['nvda_version'], 'latest'), variables['nvda_version'], '') }}
       downloadPath: $(helper_dir)/nvda-portable
   - task: PowerShell@2
     displayName: Setup NVDA_PORTABLE_ZIP

--- a/.pipelines/windows-nvda.yml
+++ b/.pipelines/windows-nvda.yml
@@ -85,21 +85,23 @@ steps:
   - checkout: nvda-at-automation
     path: helper/nvda-at-automation
     displayName: Checkout nvda-at-automation
-  - task: PowerShell@2
-    displayName: Debug
-    inputs:
-      targetType: inline
-      ${{ if ne(variables.NVDA_VERSION, 'latest') }}:
-        script: Write-Host "Evaluated to true (${env:nvda_version})"
   - task: DownloadGitHubRelease@0
+    condition: eq(variables.nvda_version, 'latest')
+    displayName: Download latest nvda portable
+    # https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/download-github-release-v0?view=azure-pipelines
+    inputs:
+      connection: MyGitHubServiceConnection
+      userRepository: bocoup/aria-at-automation-nvda-builds
+      defaultVersionType: specificTag
+      version: $(nvda_version)
+      downloadPath: $(helper_dir)/nvda-portable
+  - task: DownloadGitHubRelease@0
+    condition: ne(variables.nvda_version, 'latest')
     displayName: Download nvda portable $(nvda_version)
     # https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/download-github-release-v0?view=azure-pipelines
     inputs:
       connection: MyGitHubServiceConnection
       userRepository: bocoup/aria-at-automation-nvda-builds
-      ${{ if ne(variables.NVDA_VERSION, 'latest') }}:
-        defaultVersionType: specificTag
-        version: $(nvda_version)
       downloadPath: $(helper_dir)/nvda-portable
   - task: PowerShell@2
     displayName: Setup NVDA_PORTABLE_ZIP

--- a/.pipelines/windows-nvda.yml
+++ b/.pipelines/windows-nvda.yml
@@ -91,7 +91,7 @@ steps:
     inputs:
       connection: MyGitHubServiceConnection
       userRepository: bocoup/aria-at-automation-nvda-builds
-      defaultVersionType: ${{ if ne(variables.nvda_version, 'latest') }}:specificTag${{ else }}:latestByTag
+      defaultVersionType: $[if(ne(variables['nvda_version'], 'latest'), 'specificTag', 'latestByTag')]
       version: $(nvda_version)
       downloadPath: $(helper_dir)/nvda-portable
   - task: PowerShell@2

--- a/.pipelines/windows-nvda.yml
+++ b/.pipelines/windows-nvda.yml
@@ -244,8 +244,7 @@ steps:
         Invoke-WebRequest $env:ARIA_AT_STATUS_URL -Headers $headers -Method 'POST' -Body $body
   - task: PublishPipelineArtifact@1
     displayName: Publish logs
-    # always run
-    condition: or(failed(), succeeded())
+    condition: always()
     inputs:
       targetPath: $(helper_dir)
       artifact: logs

--- a/.pipelines/windows-nvda.yml
+++ b/.pipelines/windows-nvda.yml
@@ -56,7 +56,7 @@ steps:
       version: "20.x"
   - task: PowerShell@2
     displayName: Log job state QUEUED
-    condition: ne(variables.STATUS_URL, '')
+    condition: ne(variables.status_url, '')
     inputs:
       targetType: inline
       script: |

--- a/.pipelines/windows-nvda.yml
+++ b/.pipelines/windows-nvda.yml
@@ -85,14 +85,21 @@ steps:
   - checkout: nvda-at-automation
     path: helper/nvda-at-automation
     displayName: Checkout nvda-at-automation
+  - task: PowerShell@2
+    displayName: Debug
+    inputs:
+      targetType: inline
+      ${{ if ne(variables.nvda_version, 'latest') }}:
+        script: Write-Host "Evaluated to true"
   - task: DownloadGitHubRelease@0
     displayName: Download nvda portable $(nvda_version)
     # https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/download-github-release-v0?view=azure-pipelines
     inputs:
       connection: MyGitHubServiceConnection
       userRepository: bocoup/aria-at-automation-nvda-builds
-      defaultVersionType: ${{ if(ne(variables['nvda_version'], 'latest'), 'specificTag', 'latestByTag') }}
-      version: ${{ if(ne(variables['nvda_version'], 'latest'), variables['nvda_version'], '') }}
+      ${{ if ne(variables.nvda_version, 'latest') }}:
+        defaultVersionType: specificTag
+        version: $(nvda_version)
       downloadPath: $(helper_dir)/nvda-portable
   - task: PowerShell@2
     displayName: Setup NVDA_PORTABLE_ZIP

--- a/.pipelines/windows-nvda.yml
+++ b/.pipelines/windows-nvda.yml
@@ -9,6 +9,19 @@ variables:
   - name: helper_dir
     value: '$(Agent.BuildDirectory)\helper'
 
+# This pipeline expects the following variables to be defined in the Azure DevOps
+# Web UI and configured to be settable/overridable at "queue time". Some of them have
+# default values which are also here.
+#
+# - aria_at_ref = master
+# - browser = chrome
+# - callback_header
+# - callback_url
+# - nvda_version = latest
+# - status_url
+# - test_pattern = {reference/**,test-*-nvda.*}
+# - work_dir = tests/alert
+
 resources:
   repositories:
     - repository: nvda-at-automation

--- a/.pipelines/windows-nvda.yml
+++ b/.pipelines/windows-nvda.yml
@@ -91,9 +91,8 @@ steps:
     inputs:
       connection: MyGitHubServiceConnection
       userRepository: bocoup/aria-at-automation-nvda-builds
-      ${{ if ne(variables.nvda_version, 'latest') }}:
-        defaultVersionType: specificTag
-        version: $(nvda_version)
+      defaultVersionType: ${{ if ne(variables.nvda_version, 'latest') }}:specificTag${{ else }}:latestByTag
+      version: $(nvda_version)
       downloadPath: $(helper_dir)/nvda-portable
   - task: PowerShell@2
     displayName: Setup NVDA_PORTABLE_ZIP

--- a/.pipelines/windows-nvda.yml
+++ b/.pipelines/windows-nvda.yml
@@ -6,45 +6,8 @@ pool:
   vmImage: windows-latest
 
 variables:
-  - name: empty
-    value: ""
   - name: helper_dir
     value: '$(Agent.BuildDirectory)\helper'
-  - name: callback_url
-    value: ""
-
-parameters:
-  - name: aria_at_ref
-    type: string
-    default: master
-    displayName: ARIA-AT Reference Branch
-  - name: browser
-    type: string
-    default: chrome
-    displayName: Browser to Test
-    values:
-      - chrome
-      - firefox
-  - name: nvda_version
-    type: string
-    default: "latest"
-    displayName: NVDA Version
-  - name: test_pattern
-    type: string
-    default: "{reference/**,test-*-nvda.*}"
-    displayName: Test Pattern
-  - name: work_dir
-    type: string
-    default: "tests/alert"
-    displayName: Working Directory
-  - name: callback_header
-    type: string
-    default: $(empty)
-    displayName: Callback Header
-  - name: status_url
-    type: string
-    default: NONE
-    displayName: Status URL
 
 resources:
   repositories:
@@ -75,47 +38,25 @@ steps:
   # Method borrowed from https://stackoverflow.com/a/63959970
   - task: PowerShell@2
     displayName: Setup env vars
-    env:
-      p_work_dir: ${{ parameters['work_dir'] }}
-      p_test_pattern: ${{ parameters['test_pattern'] }}
-      p_status_url: ${{ parameters['status_url'] }}
-      p_callback_header: ${{ parameters['callback_header'] }}
-      p_browser: ${{ parameters['browser'] }}
-      p_nvda_version: ${{ parameters['nvda_version'] }}
     inputs:
       targetType: inline
       script: |
-        Write-Host "Making inputs available as an environment variable."
-        Write-Host "##vso[task.setvariable variable=ARIA_AT_WORK_DIR;]$env:p_work_dir"
-        Write-Host "ARIA_AT_WORK_DIR: $env:ARIA_AT_WORK_DIR ($env:p_work_dir)"
-        Write-Host "##vso[task.setvariable variable=ARIA_AT_TEST_PATTERN;]$env:p_test_pattern"
-        Write-Host "ARIA_AT_TEST_PATTERN: $env:ARIA_AT_TEST_PATTERN ($env:p_test_pattern)"
-        Write-Host "##vso[task.setvariable variable=ARIA_AT_STATUS_URL;]${{ parameters['status_url'] }}"
-        Write-Host "ARIA_AT_STATUS_URL: $env:ARIA_AT_STATUS_URL (${{ parameters['status_url'] }})"
-        Write-Host "##vso[task.setvariable variable=ARIA_AT_STATUS_URL;]$env:p_status_url"
-        Write-Host "ARIA_AT_STATUS_URL: $env:ARIA_AT_STATUS_URL ($env:p_status_url)"
-        Write-Host "##vso[task.setvariable variable=ARIA_AT_CALLBACK_HEADER;]$env:p_callback_header"
-        Write-Host "ARIA_AT_CALLBACK_HEADER: $env:ARIA_AT_CALLBACK_HEADER ($env:p_callback_header)"
-        Write-Host "##vso[task.setvariable variable=BROWSER;]$env:p_browser"
-        Write-Host "BROWSER: $env:BROWSER ($env:p_browser)"
-        Write-Host "##vso[task.setvariable variable=NVDA_VERSION;]$env:p_nvda_version"
-        Write-Host "NVDA_VERSION: $env:NVDA_VERSION ($env:p_nvda_version)"
+        Write-Host "Making inputs available as environment variables expected by scripts."
+        Write-Host "##vso[task.setvariable variable=ARIA_AT_WORK_DIR;]${env:work_dir}"
+        Write-Host "##vso[task.setvariable variable=ARIA_AT_TEST_PATTERN;]${env:test_pattern}"
+        Write-Host "##vso[task.setvariable variable=ARIA_AT_CALLBACK_URL;]${env:callback_url}"
+        Write-Host "##vso[task.setvariable variable=ARIA_AT_STATUS_URL;]${env:status_url}"
+        Write-Host "##vso[task.setvariable variable=ARIA_AT_CALLBACK_HEADER;]${env:callback_header}"
+        Write-Host "##vso[task.setvariable variable=BROWSER;]${env:browser}"
+        Write-Host "##vso[task.setvariable variable=NVDA_VERSION;]${env:nvda_version}"
 
   - task: UseNode@1
     displayName: Install Node
     inputs:
       version: "20.x"
   - task: PowerShell@2
-    displayName: Debug Parameters
-    inputs:
-      targetType: inline
-      script: |
-        Write-Host "status_url parameter value: ${{ parameters['status_url'] }}"
-        Write-Host "status_url variable value: $env:status_url"
-        Write-Host "Pipeline status: $(Agent.JobStatus)"
-  - task: PowerShell@2
     displayName: Log job state QUEUED
-    condition: ${{ ne(variables['status_url'], '') }}
+    condition: ne(variables.STATUS_URL, '')
     inputs:
       targetType: inline
       script: |
@@ -136,23 +77,23 @@ steps:
     path: helper/aria-at
     displayName: Checkout aria-at
   - task: PowerShell@2
-    displayName: Checkout aria-at to ${{ parameters['aria_at_ref'] }}
+    displayName: Checkout aria-at to $(aria_at_ref)
     inputs:
       targetType: "inline"
       workingDirectory: $(helper_dir)/aria-at
-      script: git checkout ${{ parameters['aria_at_ref'] }}
+      script: git checkout ${env:aria_at_ref}
   - checkout: nvda-at-automation
     path: helper/nvda-at-automation
     displayName: Checkout nvda-at-automation
   - task: DownloadGitHubRelease@0
-    displayName: Download nvda portable ${{ parameters['nvda_version'] }}
+    displayName: Download nvda portable $(nvda_version)
     # https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/download-github-release-v0?view=azure-pipelines
     inputs:
       connection: MyGitHubServiceConnection
       userRepository: bocoup/aria-at-automation-nvda-builds
-      ${{ if ne(parameters['nvda_version'], 'latest')}}:
+      ${{ if ne(variables.nvda_version, 'latest') }}:
         defaultVersionType: specificTag
-        version: ${{ parameters['nvda_version'] }}
+        version: $(nvda_version)
       downloadPath: $(helper_dir)/nvda-portable
   - task: PowerShell@2
     displayName: Setup NVDA_PORTABLE_ZIP
@@ -202,8 +143,7 @@ steps:
       command: "install"
   - task: PowerShell@2
     displayName: Log job state RUNNING
-    # weird syntaxing because parameters only exists in ${{ }} land, but succeeded() doesn't exist there
-    condition: and(succeeded(), ${{ ne(parameters['status_url'], 'NONE') }} )
+    condition: and(succeeded(), ne(variables.status_url, ''))
     inputs:
       targetType: inline
       script: |
@@ -222,8 +162,7 @@ steps:
 
   - task: PowerShell@2
     displayName: Log job state ERROR
-    # weird syntaxing because parameters only exists in ${{ }} land, but failed() doesn't exist there
-    condition: and(failed(), ${{ ne(parameters['status_url'], 'NONE') }} )
+    condition: and(failed(), ne(variables.status_url, ''))
     inputs:
       targetType: inline
       script: |
@@ -233,8 +172,7 @@ steps:
         Invoke-WebRequest $env:ARIA_AT_STATUS_URL -Headers $headers -Method 'POST' -Body $body
   - task: PowerShell@2
     displayName: Log job state COMPLETED
-    # weird syntaxing because parameters only exists in ${{ }} land, but succeeded() doesn't exist there
-    condition: and(succeeded(), ${{ ne(parameters['status_url'], 'NONE') }} )
+    condition: and(succeeded(), ne(variables.status_url, ''))
     inputs:
       targetType: inline
       script: |

--- a/.pipelines/windows-nvda.yml
+++ b/.pipelines/windows-nvda.yml
@@ -92,7 +92,7 @@ steps:
       connection: MyGitHubServiceConnection
       userRepository: bocoup/aria-at-automation-nvda-builds
       defaultVersionType: $[if(ne(variables['nvda_version'], 'latest'), 'specificTag', 'latestByTag')]
-      version: $(nvda_version)
+      version: $[if(ne(variables['nvda_version'], 'latest'), variables['nvda_version'], '')]
       downloadPath: $(helper_dir)/nvda-portable
   - task: PowerShell@2
     displayName: Setup NVDA_PORTABLE_ZIP


### PR DESCRIPTION
Unfortunately in my testing, the Azure DevOps REST API doesn't support setting "parameters", which are distinct from "variables". Furthermore, there are variables that are defined in the pipelines yaml file, but you can also define variables in the Azure Pipelines web UI. Variables defined in the YAML are not configurable outside of the YAML, aka you cannot set these programmatically when the build is triggered. Variables defined in the web UI can be configured to be settable at "queue time" which is when the build is triggered, either manually or via the REST API.

These UI variables have some kind of legacy status in Azure Pipelines, but they seem so to be the only way the REST API supports setting variables dynamically.

This PR reworks the azure pipeline file to rely on these queue time variables and has the following set up in the azure pipelines web UI:

- aria_at_ref
- browser
- callback_header
- callback_url
- nvda_version
- status_url
- test_pattern
- work_dir

<img width="493" alt="screenshot of azure pipelines web ui showing a list of configured variables" src="https://github.com/user-attachments/assets/9393ce39-e91c-4f1c-95f7-af5129f8dfd2" />

This PR also removes some debugging info I had previously added to the pipeline file.