### PR TITLE
Introduce a CLI option for test plans

### DIFF
--- a/stressor/package-lock.json
+++ b/stressor/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@commander-js/extra-typings": "^13.0.0",
         "@octokit/rest": "^21.0.1",
         "@types/lodash.isequal": "^4.5.8",
-        "commander": "^13.0.0",
         "jest-diff": "^29.7.0",
         "lodash.isequal": "^4.5.0",
         "ngrok": "^5.0.0-beta.2",
@@ -29,6 +29,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@commander-js/extra-typings": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-13.0.0.tgz",
+      "integrity": "sha512-4or44L3saI49QRBvdSzfCtzqONlFg0/qy0Cfl+LRynDaxlGs7r2KRTLCELaAoKh4oQguICxRwQfm77/Up+0wTw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "commander": "~13.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -865,6 +874,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
       "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/stressor/package.json
+++ b/stressor/package.json
@@ -9,9 +9,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@commander-js/extra-typings": "^13.0.0",
     "@octokit/rest": "^21.0.1",
     "@types/lodash.isequal": "^4.5.8",
-    "commander": "^13.0.0",
     "jest-diff": "^29.7.0",
     "lodash.isequal": "^4.5.0",
     "ngrok": "^5.0.0-beta.2",


### PR DESCRIPTION
Require the leading "tests/" to reinforce the values' relationship to the ARIA-AT project repository.

(I think the "tests/" prefix requirement is useful friction (particularly because we lack a way to validate the existence of directories), but I won't fight if folks think it's gross.)