### PR TITLE
Use harness as published to NPM

### DIFF
--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -95,12 +95,8 @@ jobs:
           path: "aria-at"
           ref: ${{ inputs.aria_at_ref || 'master' }}
 
-      - name: Checkout aria-at-automation-harness
-        uses: actions/checkout@v4
-        with:
-          repository: "w3c/aria-at-automation-harness"
-          ref: "main"
-          path: "aria-at-automation-harness"
+      - name: Install the ARIA-AT Automation Harness package
+        run: npm install aria-at-automation-harness@"~0.0.1"
 
       - name: Download nvda-portable zip
         uses: robinraju/release-downloader@v1.9
@@ -165,12 +161,6 @@ jobs:
         run: |
           cd aria-at
           npm run build
-
-      - name: "automation-harness: npm install"
-        shell: powershell
-        run: |
-          cd aria-at-automation-harness
-          npm install
 
       - name: Log job state RUNNING
         shell: powershell

--- a/.github/workflows/voiceover-test.yml
+++ b/.github/workflows/voiceover-test.yml
@@ -115,11 +115,8 @@ jobs:
           path: "aria-at"
           ref: ${{ inputs.aria_at_ref || 'master' }}
 
-      - name: Checkout aria-at-automation-harness
-        uses: actions/checkout@v4
-        with:
-          repository: "w3c/aria-at-automation-harness"
-          path: "aria-at-automation-harness"
+      - name: Install the ARIA-AT Automation Harness package
+        run: npm install aria-at-automation-harness@"~0.0.1"
 
       - name: "aria-at: npm install"
         working-directory: aria-at
@@ -128,10 +125,6 @@ jobs:
       - name: "aria-at: npm run build"
         working-directory: aria-at
         run: npm run build
-
-      - name: "automation-harness: npm install"
-        working-directory: aria-at-automation-harness
-        run: npm install
 
       - name: Start VoiceOver
         run: "/System/Library/CoreServices/VoiceOver.app/Contents/MacOS/VoiceOverStarter"

--- a/run-tester.ps1
+++ b/run-tester.ps1
@@ -108,7 +108,7 @@ $bmp.Save("$loglocation\test.png")
 
 Write-Output "Launching automation-harness host"
 $hostParams = "--debug"
-node aria-at-automation-harness/bin/host.js  run-plan --plan-workingdir aria-at/build/$env:ARIA_AT_WORK_DIR $env:ARIA_AT_TEST_PATTERN $hostParams --web-driver-url=http://127.0.0.1:4444 --at-driver-url=ws://127.0.0.1:3031/command --reference-hostname=127.0.0.1 --web-driver-browser=$env:BROWSER | Tee-Object -FilePath $loglocation\harness-run.log
+./node_modules/.bin/aria-at-harness-host  run-plan --plan-workingdir aria-at/build/$env:ARIA_AT_WORK_DIR $env:ARIA_AT_TEST_PATTERN $hostParams --web-driver-url=http://127.0.0.1:4444 --at-driver-url=ws://127.0.0.1:3031/command --reference-hostname=127.0.0.1 --web-driver-browser=$env:BROWSER | Tee-Object -FilePath $loglocation\harness-run.log
 
 $graphics.CopyFromScreen($bounds.Location, [Drawing.Point]::Empty, $bounds.size)
 $bmp.Save("$loglocation\test2.png")

--- a/run-tester.sh
+++ b/run-tester.sh
@@ -73,7 +73,7 @@ case ${BROWSER} in
     ;;
 esac
 
-node aria-at-automation-harness/bin/host.js run-plan \
+node_modules/.bin/aria-at-harness-host run-plan \
   --plan-workingdir aria-at/build/${ARIA_AT_WORK_DIR} \
   --debug \
   --web-driver-url=${webdriver_url} \


### PR DESCRIPTION
This is a corrected version of the patch originally merged as commit 917aa1. It corrects the problem which forced the reversion of that commit by modifying the way the executable Node script is invoked in Windows.

Previously, the incorrect statement read as follows (in part):

    node ./node_modules/.bin/aria-at-harness-host run-plan

This patch omits the `node` executable from that command:

    ./node_modules/.bin/aria-at-harness-host run-plan

This is necessary because in Windows environments, the executable file is not a JavaScript file:
https://stackoverflow.com/questions/54028280/git-bash-syntaxerror-missing-after-argument-list