### PR TITLE
adds subset of timeout options for harness

### DIFF
--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -75,8 +75,8 @@ env:
   ARIA_AT_CALLBACK_HEADER: ${{ inputs.callback_header || 'x-header-param:empty' }}
   BROWSER: ${{ inputs.browser || 'chrome' }}
   NVDA_VERSION: ${{ inputs.nvda_version }}
-  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav || 1000 }}
-  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready || 2000 }}
+  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav}}
+  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready }}
 
 jobs:
   nvda-test:

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -50,12 +50,12 @@ on:
         description: |
           Timeout used after navigation to collect and discard speech.
         required: false
-        type: number
+        type: string
       timeout_after_doc_ready:
         description: |
           Timeout used waiting for document ready (Safari).
         required: false
-        type: number
+        type: string
       nvda_version:
         description: |
           The specific version of NVDA to use (e.g., '2023.1'). If not provided, the latest version will be used.
@@ -75,8 +75,8 @@ env:
   ARIA_AT_CALLBACK_HEADER: ${{ inputs.callback_header || 'x-header-param:empty' }}
   BROWSER: ${{ inputs.browser || 'chrome' }}
   NVDA_VERSION: ${{ inputs.nvda_version }}
-  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav}}
-  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready }}
+  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav || '1000'}}
+  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready || '2000' }}
 
 jobs:
   nvda-test:

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -46,6 +46,16 @@ on:
           The browser to use for testing, "chrome" or "firefox", default "chrome"
         required: false
         type: string
+      timeout_after_nav:
+        description: |
+          Timeout used after navigation to collect and discard speech.
+        required: false
+        type: number
+      timeout_after_doc_ready:
+        description: |
+          Timeout used waiting for document ready (Safari).
+        required: false
+        type: number
       nvda_version:
         description: |
           The specific version of NVDA to use (e.g., '2023.1'). If not provided, the latest version will be used.
@@ -65,6 +75,8 @@ env:
   ARIA_AT_CALLBACK_HEADER: ${{ inputs.callback_header || 'x-header-param:empty' }}
   BROWSER: ${{ inputs.browser || 'chrome' }}
   NVDA_VERSION: ${{ inputs.nvda_version }}
+  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav || '1000' }}
+  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready || '2000' }}
 
 jobs:
   nvda-test:

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -75,8 +75,8 @@ env:
   ARIA_AT_CALLBACK_HEADER: ${{ inputs.callback_header || 'x-header-param:empty' }}
   BROWSER: ${{ inputs.browser || 'chrome' }}
   NVDA_VERSION: ${{ inputs.nvda_version }}
-  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav || '1000' }}
-  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready || '2000' }}
+  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav || 1000 }}
+  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready || 2000 }}
 
 jobs:
   nvda-test:

--- a/.github/workflows/voiceover-test.yml
+++ b/.github/workflows/voiceover-test.yml
@@ -69,8 +69,8 @@ env:
   ARIA_AT_CALLBACK_HEADER: ${{ inputs.callback_header || 'x-header-param:empty' }}
   BROWSER: ${{ inputs.browser || 'safari' }}
   AT_DRIVER_SERVER_VERSION: ${{ inputs.at_driver_server_version }}
-  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav }}
-  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready }}
+  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav || '1000' }}
+  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready || '2000' }}
 
 jobs:
   voiceover-test:

--- a/.github/workflows/voiceover-test.yml
+++ b/.github/workflows/voiceover-test.yml
@@ -45,6 +45,16 @@ on:
           The browser to use for testing, "chrome" or "firefox" or "safari", default "safari"
         required: false
         type: string
+      timeout_after_nav:
+        description: |
+          Timeout used after navigation to collect and discard speech.
+        required: false
+        type: number
+      timeout_after_doc_ready:
+        description: |
+          Timeout used waiting for document ready (Safari).
+        required: false
+        type: number
       at_driver_server_version:
         description: |
           The version or version range of the macOS AT Driver server to install from npm

--- a/.github/workflows/voiceover-test.yml
+++ b/.github/workflows/voiceover-test.yml
@@ -69,8 +69,8 @@ env:
   ARIA_AT_CALLBACK_HEADER: ${{ inputs.callback_header || 'x-header-param:empty' }}
   BROWSER: ${{ inputs.browser || 'safari' }}
   AT_DRIVER_SERVER_VERSION: ${{ inputs.at_driver_server_version }}
-  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav || '1000' }}
-  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready || '2000' }}
+  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav || 1000 }}
+  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready || 2000 }}
 
 jobs:
   voiceover-test:

--- a/.github/workflows/voiceover-test.yml
+++ b/.github/workflows/voiceover-test.yml
@@ -69,6 +69,8 @@ env:
   ARIA_AT_CALLBACK_HEADER: ${{ inputs.callback_header || 'x-header-param:empty' }}
   BROWSER: ${{ inputs.browser || 'safari' }}
   AT_DRIVER_SERVER_VERSION: ${{ inputs.at_driver_server_version }}
+  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav }}
+  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready }}
 
 jobs:
   voiceover-test:

--- a/.github/workflows/voiceover-test.yml
+++ b/.github/workflows/voiceover-test.yml
@@ -49,12 +49,12 @@ on:
         description: |
           Timeout used after navigation to collect and discard speech.
         required: false
-        type: number
+        type: string
       timeout_after_doc_ready:
         description: |
           Timeout used waiting for document ready (Safari).
         required: false
-        type: number
+        type: string
       at_driver_server_version:
         description: |
           The version or version range of the macOS AT Driver server to install from npm
@@ -69,8 +69,8 @@ env:
   ARIA_AT_CALLBACK_HEADER: ${{ inputs.callback_header || 'x-header-param:empty' }}
   BROWSER: ${{ inputs.browser || 'safari' }}
   AT_DRIVER_SERVER_VERSION: ${{ inputs.at_driver_server_version }}
-  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav || 1000 }}
-  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready || 2000 }}
+  TIMEOUT_AFTER_NAV: ${{ inputs.timeout_after_nav || '1000' }}
+  TIMEOUT_AFTER_DOC_READY: ${{ inputs.timeout_after_doc_ready || '2000' }}
 
 jobs:
   voiceover-test:

--- a/run-tester.sh
+++ b/run-tester.sh
@@ -80,7 +80,7 @@ node aria-at-automation-harness/bin/host.js run-plan \
   --at-driver-url=ws://127.0.0.1:3031/session \
   --reference-hostname=127.0.0.1 \
   --web-driver-browser=${BROWSER} \
-  --time-after-nav={TIMEOUT_AFTER_NAV} \
-  --time-doc-ready={TIMEOUT_AFTER_DOC_READY} \
+  --time-after-nav=${TIMEOUT_AFTER_NAV} \
+  --time-doc-ready=${TIMEOUT_AFTER_DOC_READY} \
   '{reference/**,test-*-voiceover_macos.*}' 2>&1 | \
     tee harness-run.log

--- a/run-tester.sh
+++ b/run-tester.sh
@@ -80,5 +80,7 @@ node aria-at-automation-harness/bin/host.js run-plan \
   --at-driver-url=ws://127.0.0.1:3031/session \
   --reference-hostname=127.0.0.1 \
   --web-driver-browser=${BROWSER} \
+  --time-after-nav={TIMEOUT_AFTER_NAV} \
+  --time-doc-ready={TIMEOUT_AFTER_DOC_READY} \
   '{reference/**,test-*-voiceover_macos.*}' 2>&1 | \
     tee harness-run.log

--- a/stressor/stress-test.mts
+++ b/stressor/stress-test.mts
@@ -97,8 +97,8 @@ const testingMatrix = [
 
 const workflowHeaderKey = 'x-workflow-key';
 
-const timeAfterNav = 2000;
-const timeDocReady = 3000;
+const timeAfterNav = '2000';
+const timeDocReady = '3000';
 
 interface WorkflowCallbackPayload {
   status: string;

--- a/stressor/stress-test.mts
+++ b/stressor/stress-test.mts
@@ -97,6 +97,9 @@ const testingMatrix = [
 
 const workflowHeaderKey = 'x-workflow-key';
 
+const timeAfterNav = 2000;
+const timeDocReady = 3000;
+
 interface WorkflowCallbackPayload {
   status: string;
   testCsvRow?: number;
@@ -297,6 +300,8 @@ async function dispatchWorkflowForTestCombo(
         work_dir: workflowTestPlan,
         callback_url: ngrokUrl,
         status_url: ngrokUrl,
+        timeout_after_nav: timeAfterNav,
+        timeout_after_doc_ready: timeDocReady,
         callback_header: `${workflowHeaderKey}:${getWorkflowRunKey(
           testCombo,
           runIndex


### PR DESCRIPTION
I suspect that using a higher timeout after starting up Safari in CI may resolve some issues we've seen where the VO Bot seems to navigate to the wrong place, like in these issues:

- https://github.com/w3c/aria-at-app/issues/1294
- https://github.com/w3c/aria-at-app/issues/1291
- Possibly even https://github.com/w3c/aria-at-app/issues/1298 

Using higher timeouts when the harness locally also seems to resolve some of these issues. If this does make a difference after running a new consistency report, we may actually just want to update some of the [timeout defaults on the harness itself](https://github.com/w3c/aria-at-automation-harness/blob/main/src/shared/times-option.js#L8-L14). 