### PR TITLE
Pin nvda driver SHA

### DIFF
--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           repository: "Prime-Access-Consulting/nvda-at-automation"
           path: "nvda-at-automation"
+          ref: 0699f2a
 
       - name: Checkout aria-at ref ${{ inputs.aria_at_ref || 'master' }}
         uses: actions/checkout@v4

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           repository: "Prime-Access-Consulting/nvda-at-automation"
           path: "nvda-at-automation"
-          ref: 0699f2a
+          ref: 0699f2ab4267379d9f05c82916009f9d62c9910a
 
       - name: Checkout aria-at ref ${{ inputs.aria_at_ref || 'master' }}
         uses: actions/checkout@v4


### PR DESCRIPTION
So we can send a PR upstream and be ready to swap this to the new "main" when it's landed.

Test run of job on branch: https://github.com/bocoup/aria-at-gh-actions-helper/actions/runs/13823173161/job/38672976069#step:4:62