### PR TITLE
strip ansi for diff output

### DIFF
--- a/stressor/lib/diff.mts
+++ b/stressor/lib/diff.mts
@@ -1,0 +1,14 @@
+import { DiffOptions, DiffOptionsColor, diff as jestDiff } from 'jest-diff';
+
+const noColor: DiffOptionsColor = string => string;
+const options: DiffOptions = {
+  aColor: noColor,
+  bColor: noColor,
+  changeColor: noColor,
+  commonColor: noColor,
+  patchColor: noColor
+};
+
+export default function diff(a: string | null, b: string | null): string {
+  return jestDiff(a, b, options) || '';
+}

--- a/stressor/stress-test.mts
+++ b/stressor/stress-test.mts
@@ -724,7 +724,7 @@ const formatResultsForMD = (
             diff(
               formatResponses(comparedResult.baselineResponses),
               formatResponses(diverges.responses)
-            ) || ''
+            )
           );
           output('```');
         }

--- a/stressor/stress-test.mts
+++ b/stressor/stress-test.mts
@@ -1,7 +1,7 @@
 import * as http from 'node:http';
 import ngrok from 'ngrok';
 import { Octokit } from '@octokit/rest';
-import { diff } from 'jest-diff';
+import diff from './lib/diff.mts';
 import test, { run } from 'node:test';
 import wrap from 'word-wrap';
 import pLimit from 'p-limit';

--- a/stressor/tsconfig.json
+++ b/stressor/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
     "esModuleInterop": false,
     "skipDefaultLibCheck": true,
     "noEmit": true


### PR DESCRIPTION
Small fix for the output of the diff - having the option to save it to a file now made the ansi colors break in the markdown