### PR TITLE
fixup! strip ansi color from diff output for markdown file

### DIFF
--- a/stressor/stress-test.mts
+++ b/stressor/stress-test.mts
@@ -724,7 +724,7 @@ const formatResultsForMD = (
             diff(
               formatResponses(comparedResult.baselineResponses),
               formatResponses(diverges.responses)
-            ) || ''
+            )
           );
           output('```');
         }


### PR DESCRIPTION
Hey @gnarf, this seemed to minor to bug you about, but also a bit silly to do as a follow-up