### PR TITLE
Improve logging

### DIFF
--- a/run-tester.ps1
+++ b/run-tester.ps1
@@ -69,24 +69,6 @@ switch ($env:BROWSER)
   }
 }
 
-function Trace-Logs {
-  if ($env:RUNNER_DEBUG)
-  {
-    Write-Output "At-Driver job process log:"
-    Receive-Job $atprocess
-    Write-Output "--at-driver.log"
-    Get-Content -Path $loglocation\at-driver.log -ErrorAction Continue
-    Write-Output "WebDriver server job process log:"
-    Receive-Job $webdriverprocess
-    Write-Output "--webdriver.log"
-    Get-Content -Path $loglocation\webdriver.log -ErrorAction Continue
-    Write-Output "--nvda.log"
-    Get-Content -Path $env:TEMP\nvda.log -ErrorAction Continue
-  }
-}
-
-Trace-Logs
-
 Add-Type -AssemblyName System.Windows.Forms,System.Drawing
 $screens = [Windows.Forms.Screen]::AllScreens
 $top    = ($screens.Bounds.Top    | Measure-Object -Minimum).Minimum
@@ -121,5 +103,3 @@ $bmp.Dispose()
 Set-Location ..
 get-process > .\get-process.log
 Copy-Item -Path $env:TEMP\nvda.log -Destination $loglocation -ErrorAction Continue
-
-Trace-Logs

--- a/run-tester.ps1
+++ b/run-tester.ps1
@@ -4,15 +4,10 @@ $loglocation = $pwd
 
 Write-Output "Log folder $loglocation"
 
-$nvdaParams = ""
-if ($env:RUNNER_DEBUG)
-{
-  $nvdaParams = "--debug-logging"
-}
 [string]$nvdaFolder = [System.IO.Path]::GetDirectoryName($env:NVDA_PORTABLE_ZIP)
 Expand-Archive -Path "$env:NVDA_PORTABLE_ZIP" -DestinationPath "$nvdaFolder"
 Write-Output "Starting NVDA $nvdaVersion - $nvdaFolder\$nvdaVersion\nvda.exe"
-& "$nvdaFolder\$nvdaVersion\nvda.exe" $nvdaParams
+& "$nvdaFolder\$nvdaVersion\nvda.exe" --debug-logging
 
 # Retries to connect to an http url, allowing for any valid "response" (4xx,5xx,etc also valid)
 function Wait-For-HTTP-Response {


### PR DESCRIPTION
@gnarf I'm especially interested in your thoughts on the removal of "Trace-Logs". That function combines distinct streams of logging information, and that makes it harder for me to understand the context of any given line of output. Additionally, because `run-tester.ps1` invokes the function twice (and the relevant logs are not cleared between invocations), a lot of information is duplicated in standard output.