### PR TITLE
removes firefox from testing matrix used in consistency reports

### DIFF
--- a/stressor/stress-test.mts
+++ b/stressor/stress-test.mts
@@ -103,7 +103,7 @@ const testingMatrix = [
   },
   {
     workflowId: 'voiceover-test.yml',
-    browsers: ['safari', 'chrome', 'firefox']
+    browsers: ['safari', 'chrome']
   }
 ];
 


### PR DESCRIPTION
To align with the priority combinations tested by the ARIA-AT CG:
**Current Priority**
- NVDA + Chrome
- JAWS + Chrome
- VO + Safari

per @howard-e :
> When versions eventually get to RECOMMENDED, 3 additional combinations will be prioritized for them to be considered fully recommended:
> JAWS + Firefox
> NVDA + Firefox
> VO + Chrome