### PR TITLE
Draft: add timing and retries to markdown output

### DIFF
--- a/stressor/stress-test.mts
+++ b/stressor/stress-test.mts
@@ -10,6 +10,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { Command, InvalidArgumentError } from '@commander-js/extra-typings';
 import { createWriteStream, WriteStream } from 'node:fs';
 import { PassThrough } from 'node:stream';
+import formatDuration from './lib/formatDuration.mts';
 
 const DEBUG = process.env.DEBUG === 'true' || process.env.DEBUG === '1';
 const limitWorkflows = pLimit(8);
@@ -715,7 +716,26 @@ const formatResultsForMD = async (
       await output(`\n### Run Logs\n`);
       let logNumber = 0;
       for (const url of comboResults.logUrls) {
-        await output(`* [Run #${logNumber++}](${url})`);
+        const runId = url.slice(url.lastIndexOf('/') + 1);
+        const { data } = await octokitClient.actions.getWorkflowRunUsage({
+          owner: options.owner,
+          repo: options.repo,
+          run_id: parseInt(runId, 10)
+        });
+        const runTime = data.run_duration_ms ?? 0;
+
+        const {
+          data: { run_attempt: attemptNumber = 1 }
+        } = await octokitClient.actions.getWorkflowRun({
+          owner: options.owner,
+          repo: options.repo,
+          run_id: parseInt(runId, 10)
+        });
+        const retries = attemptNumber - 1;
+        const retriesText = retries > 0 ? ` - ${retries} retries` : '';
+        await output(
+          `* [Run #${logNumber++}](${url}) - ${formatDuration(runTime)}${retriesText}`
+        );
       }
       for (const comparedResult of comboResults.comparedResults) {
         await output(`\n### Test Number: ${comparedResult.testCsvRow}\n`);


### PR DESCRIPTION
I'm putting this up in "draft" mode because I do really want to discuss what else we might want to store about these in the "json" outputs.

Right now, the retreval of this data is being done in the "report generation" logic, but I think it might be better if we grabbed this data as a part of the "collection" process and stored it in the output json files.  We don't really >need< anything other than the runtimes and the retries count for the output right now, but it could be useful to store the whole output of the `getWorkflowRunUsage` and `getWorkflowRun` for other possible data retrieval in the future.

Please feel free to review as is, but really looking for feedback on wether @jugglinmike and @ChrisC feel like storing this data in the JSON long term seems like a smart plan/worth my time to update the json storage.  If we are okay with just doing these fetches during the "report generation" then I suppose we can land this as is.  Please let me know how ya'll feel about it