### PR TITLE
update to userIntent versions for nvda workflow

### DIFF
--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           repository: "Prime-Access-Consulting/nvda-at-automation"
           path: "nvda-at-automation"
-          ref: 0699f2ab4267379d9f05c82916009f9d62c9910a
+          ref: 0fc1ce292cd93ddceadc7d7a4a013460fcf6092a
 
       - name: Checkout aria-at ref ${{ inputs.aria_at_ref || 'master' }}
         uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
           ref: ${{ inputs.aria_at_ref || 'master' }}
 
       - name: Install the ARIA-AT Automation Harness package
-        run: npm install aria-at-automation-harness@"0.0.3"
+        run: npm install aria-at-automation-harness@"0.0.4"
 
       - name: Download nvda-portable zip
         uses: robinraju/release-downloader@v1.9

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -97,7 +97,7 @@ jobs:
           ref: ${{ inputs.aria_at_ref || 'master' }}
 
       - name: Install the ARIA-AT Automation Harness package
-        run: npm install aria-at-automation-harness@"0.0.4"
+        run: npm install aria-at-automation-harness@"~0.1.0"
 
       - name: Download nvda-portable zip
         uses: robinraju/release-downloader@v1.9


### PR DESCRIPTION
This is not yet complete, the draft only fixes for NVDA, we need to test and confirm "working" situation for voiceover yml as well.

We might want to set pinned version `0.0.4` for the aria-at-automation-harness so we don't accidentally an update like this again

[Here](https://github.com/gnarf/aria-at-gh-actions-helper/actions/runs/14781481308) is a (passing) test run of this branch vs NVDA.

[Here](https://github.com/gnarf/aria-at-gh-actions-helper/actions/runs/14781602901/job/41501542561#step:23:47) is a (failing) test run of this branch vs Voiceover