### PR TITLE
pin automation-harness to 0.0.3

### DIFF
--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -97,7 +97,7 @@ jobs:
           ref: ${{ inputs.aria_at_ref || 'master' }}
 
       - name: Install the ARIA-AT Automation Harness package
-        run: npm install aria-at-automation-harness@"~0.0.1"
+        run: npm install aria-at-automation-harness@"0.0.3"
 
       - name: Download nvda-portable zip
         uses: robinraju/release-downloader@v1.9

--- a/.github/workflows/voiceover-test.yml
+++ b/.github/workflows/voiceover-test.yml
@@ -116,7 +116,7 @@ jobs:
           ref: ${{ inputs.aria_at_ref || 'master' }}
 
       - name: Install the ARIA-AT Automation Harness package
-        run: npm install aria-at-automation-harness@"~0.0.1"
+        run: npm install aria-at-automation-harness@"0.0.3"
 
       - name: "aria-at: npm install"
         working-directory: aria-at


### PR DESCRIPTION
Here is the version that pins to 0.0.3

✅  [Here](https://github.com/bocoup/aria-at-gh-actions-helper/actions/runs/14782671489/job/41504831864) is a voiceover test run 
✅  [Here](https://github.com/bocoup/aria-at-gh-actions-helper/actions/runs/14782666617/job/41504818817) is a NVDA test run