### PR TITLE
actually push browser flag to dispatch

### DIFF
--- a/stressor/stress-test.mts
+++ b/stressor/stress-test.mts
@@ -303,7 +303,7 @@ async function dispatchWorkflowForTestCombo(
   testCombo: TestCombination,
   runIndex: number
 ): Promise<boolean> {
-  const { workflowId, workflowTestPlan } = testCombo;
+  const { workflowId, workflowTestPlan, workflowBrowser } = testCombo;
   try {
     await githubClient.actions.createWorkflowDispatch({
       owner: options.owner,
@@ -312,6 +312,7 @@ async function dispatchWorkflowForTestCombo(
       ref: options.branch,
       inputs: {
         work_dir: workflowTestPlan,
+        browser: workflowBrowser,
         callback_url: ngrokUrl,
         status_url: ngrokUrl,
         callback_header: `${workflowHeaderKey}:${getWorkflowRunKey(


### PR DESCRIPTION
This bug has been around for a while, but the consistency report has never been pushing the "browser" flag correctly to the workflow.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210794475209283