### PR TITLE
Setup some Jaws settings (temporary workaround)

### DIFF
--- a/JAWS/InstallJAWSUnattended.ps1
+++ b/JAWS/InstallJAWSUnattended.ps1
@@ -129,6 +129,16 @@ else
     Write-Host "[x] Outbound firewall rule already exists."
 }
 
+# temporary settings tweaking (eventually will be implemented in harness)
+Add-Content -Path "$env:APPDATA\Freedom Scientific\JAWS\2025\Settings\enu\default.jcf" -Value @"
+
+[HTML]
+SayAllOnDocumentLoad=0
+[options]
+TypingEcho=0
+"@
+
+
 #start JAWS
 # /startrcs starts JAWS with Remote Command Server enabled
 # /default suppresses JAWS startup wizard

--- a/JAWS/InstallJAWSUnattended.ps1
+++ b/JAWS/InstallJAWSUnattended.ps1
@@ -130,7 +130,13 @@ else
 }
 
 # temporary settings tweaking (eventually will be implemented in harness)
-Add-Content -Path "$env:APPDATA\Freedom Scientific\JAWS\2025\Settings\enu\default.jcf" -Value @"
+[System.IO.Directory]::CreateDirectory("$env:APPDATA\Freedom Scientific\JAWS\2025\Settings\enu\")
+$settings = "$env:APPDATA\Freedom Scientific\JAWS\2025\Settings\enu\default.jcf"
+if (-Not (Test-Path $settings))
+{
+    New-Item $settings
+}
+Add-Content -Path $settings -Value @"
 
 [HTML]
 SayAllOnDocumentLoad=0


### PR DESCRIPTION
These settings are not yet controllable via the at-driver, so we are setting up the config file before launching JAWS.

This is another "remove after we don't need it" patch for JAWS, but should result in more stable/comparable results.