### PR TITLE
Switch PowerShell 5.1 to PowerShell 7 in Windows workflows

### DIFF
--- a/.github/workflows/jaws-test.yml
+++ b/.github/workflows/jaws-test.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Log job state QUEUED
-        shell: powershell
+        shell: pwsh
         if: inputs.status_url
         run: |
           $headerbits = $env:ARIA_AT_CALLBACK_HEADER -split ":\s*", 2
@@ -115,7 +115,7 @@ jobs:
 
       # Installing Scream as a virtual audio driver to avoid exceptions later
       - name: Install Scream (Virtual Audio Driver)
-        shell: powershell
+        shell: pwsh
         run: |
           Start-Service audio*
           Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/3.6/Scream3.6.zip -OutFile C:\Scream3.6.zip
@@ -129,19 +129,19 @@ jobs:
           C:\Scream\Install\helpers\devcon install Scream.inf *Scream
 
       - name: "aria-at: npm install"
-        shell: powershell
+        shell: pwsh
         run: |
           cd aria-at
           npm install
 
       - name: "aria-at: npm run build"
-        shell: powershell
+        shell: pwsh
         run: |
           cd aria-at
           npm run build
 
       - name: Decrypt JAWS license
-        shell: powershell
+        shell: pwsh
         env:
           JAWS_SECRET: ${{ secrets.JAWS_SECRET }}
         run: |
@@ -149,19 +149,19 @@ jobs:
           gpg --quiet --batch --yes --decrypt --passphrase="$env:JAWS_SECRET" --output secret_JAWS.lic secret_JAWS.lic.gpg
 
       - name: Install and start JAWS
-        shell: powershell
+        shell: pwsh
         run: |
           cd JAWS
           & .\InstallJAWSUnattended.ps1
 
       - name: Zip JAWS install logs
-        shell: powershell
+        shell: pwsh
         if: always()
         run: |
           Compress-Archive -Path "$env:TEMP\J2025*" -CompressionLevel "Fastest" -DestinationPath "${{ github.workspace }}\JAWS-Install-logs.zip"
 
       - name: Log job state RUNNING
-        shell: powershell
+        shell: pwsh
         if: inputs.status_url
         run: |
           $headerbits = $env:ARIA_AT_CALLBACK_HEADER -split ":\s*", 2
@@ -170,13 +170,13 @@ jobs:
           Invoke-WebRequest $env:ARIA_AT_STATUS_URL -Headers $headers -Method 'POST' -Body $body
 
       - name: Run harness
-        shell: powershell
+        shell: pwsh
         timeout-minutes: 30
         run: |
           & .\run-tester.ps1
 
       - name: Log job state ERROR
-        shell: powershell
+        shell: pwsh
         if: failure() && inputs.status_url
         run: |
           $headerbits = $env:ARIA_AT_CALLBACK_HEADER -split ":\s*", 2
@@ -185,7 +185,7 @@ jobs:
           Invoke-WebRequest $env:ARIA_AT_STATUS_URL -Headers $headers -Method 'POST' -Body $body
 
       - name: Log job state COMPLETED
-        shell: powershell
+        shell: pwsh
         if: success() && inputs.status_url
         run: |
           $headerbits = $env:ARIA_AT_CALLBACK_HEADER -split ":\s*", 2

--- a/.github/workflows/nvda-test.yml
+++ b/.github/workflows/nvda-test.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
 
       - name: Log job state QUEUED
-        shell: powershell
+        shell: pwsh
         if: inputs.status_url
         run: |
           $headerbits = $env:ARIA_AT_CALLBACK_HEADER -split ":\s*", 2
@@ -131,7 +131,7 @@ jobs:
 
       # Installing Scream as a virtual audio driver to avoid exceptions later
       - name: Install Scream (Virtual Audio Driver)
-        shell: powershell
+        shell: pwsh
         run: |
           Start-Service audio*
           Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/3.6/Scream3.6.zip -OutFile C:\Scream3.6.zip
@@ -149,25 +149,25 @@ jobs:
           cache-dependency-path: nvda-at-automation/Server/go.sum
 
       - name: Compile at-automation driver
-        shell: powershell
+        shell: pwsh
         run: |
           cd nvda-at-automation\Server
           go build main\main.go
 
       - name: "aria-at: npm install"
-        shell: powershell
+        shell: pwsh
         run: |
           cd aria-at
           npm install
 
       - name: "aria-at: npm run build"
-        shell: powershell
+        shell: pwsh
         run: |
           cd aria-at
           npm run build
 
       - name: Log job state RUNNING
-        shell: powershell
+        shell: pwsh
         if: inputs.status_url
         run: |
           $headerbits = $env:ARIA_AT_CALLBACK_HEADER -split ":\s*", 2
@@ -176,7 +176,7 @@ jobs:
           Invoke-WebRequest $env:ARIA_AT_STATUS_URL -Headers $headers -Method 'POST' -Body $body
 
       - name: Run harness
-        shell: powershell
+        shell: pwsh
         timeout-minutes: 30
         env:
           NVDA_PORTABLE_ZIP: ${{ fromJson(steps.nvda-portable-download.outputs.downloaded_files)[0] }}
@@ -184,7 +184,7 @@ jobs:
           & .\run-tester.ps1
 
       - name: Log job state ERROR
-        shell: powershell
+        shell: pwsh
         if: failure() && inputs.status_url
         run: |
           $headerbits = $env:ARIA_AT_CALLBACK_HEADER -split ":\s*", 2
@@ -193,7 +193,7 @@ jobs:
           Invoke-WebRequest $env:ARIA_AT_STATUS_URL -Headers $headers -Method 'POST' -Body $body
 
       - name: Log job state COMPLETED
-        shell: powershell
+        shell: pwsh
         if: success() && inputs.status_url
         run: |
           $headerbits = $env:ARIA_AT_CALLBACK_HEADER -split ":\s*", 2


### PR DESCRIPTION
# Switch PowerShell 5.1 to PowerShell 7 in Windows workflows
### Summary
Replace `shell: powershell` (5.1) with `shell: pwsh `(7.x) in `jaws-test.yml` and `nvda-test.yml`

### Description

`Invoke-WebRequest` in PowerShell 5.1 on windows-2025 runners throws a `NullReferenceException` during TLS negotiation. Pretty sure it was caused by Github updating their `windows-2025` runner images, which explains why it appeared randomly.

Another possible fix is to explicitly use TLS 1.2 by calling `[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12` before each run, but that would keep us on the older version of PowerShell. This PR is a better fix in my opinion, since PowerShell 7's `Invoke-WebRequest` uses .NET HttpClient instead of the legacy WebRequest API and is not affected by this bug.

Closes https://github.com/w3c/aria-at-app/issues/1665

### Testing

- Example run of `nvda-test.yml` passing: https://github.com/Nicholas-Arthur-Cook/aria-at-gh-actions-helper/actions/runs/23948716518/job/69850744681
   - Here's the command I used to kick off the run (I just copied values from the last run):
```
gh workflow run nvda-test.yml \
  -f work_dir="tests/apg/quantity-spin-button" \
  -f test_pattern="{reference/**,test-*-nvda.*}" \
  -f callback_url="https://aria-at.w3.org/api/jobs/216/test/:testRowNumber" \
  -f status_url="https://aria-at.w3.org/api/jobs/216" \
  -f callback_header="x-automation-secret:cfeac008-68b3-4eaf-9952-c8599e1481b1" \
  -f browser="chrome" \
  -f nvda_version="2025.2"
```
- Can't text jaws-test because I don't have the `JAWS_SECRET`, but it should behave the same since the failure was in the `Log job state QUEUED` that is the same between NVDA and JAWS test files.